### PR TITLE
K57: Fixed up kosmos-testkit. Lots of redundancy. Still needs cleanup.

### DIFF
--- a/kosmos-testkit/src/main/kotlin/org/vorpal/kosmos/algebra/innerproduct/RealInnerProductFixtures.kt
+++ b/kosmos-testkit/src/main/kotlin/org/vorpal/kosmos/algebra/innerproduct/RealInnerProductFixtures.kt
@@ -12,8 +12,8 @@ import org.vorpal.kosmos.linear.Vec2R
 
 object RealInnerProductFixtures {
 
-    val realEq = Eqs.realUlps() /* Eq<Real> */
-    val vecEq: Eq<Vec2R> = Eq { x, y -> realEq.eqv(x.x, y.x) && realEq.eqv(x.y, y.y) }
+    val realEq = Eqs.realApprox()
+    val vecEq: Eq<Vec2R> = Eq { x, y -> realEq(x.x, y.x) && realEq(x.y, y.y) }
     val vecArb = arbVec2R()
     val scalarArb = arbFieldReal()
 
@@ -22,8 +22,7 @@ object RealInnerProductFixtures {
             space = Vec2RInnerProductSpace,
             scalarArb = scalarArb,
             vectorArb = vecArb,
-            scalarEq = realEq,
-            vectorEq = vecEq,
-            isNonNegative = { r -> r >= -1e-10 },
+            eqReal = Eqs.realApprox(),
+            eqV = vecEq
         )
 }

--- a/kosmos-testkit/src/main/kotlin/org/vorpal/kosmos/testing/OctonionArbitraries.kt
+++ b/kosmos-testkit/src/main/kotlin/org/vorpal/kosmos/testing/OctonionArbitraries.kt
@@ -6,7 +6,7 @@ import io.kotest.property.arbitrary.triple
 import io.kotest.property.arbitrary.bind
 import org.vorpal.kosmos.algebra.structures.instances.Octonion
 import org.vorpal.kosmos.algebra.structures.instances.OctonionAlgebras.normSq
-import org.vorpal.kosmos.algebra.structures.instances.OctonionAlgebras.octonion
+import org.vorpal.kosmos.algebra.structures.instances.octonion
 
 object OctonionArbitraries {
 

--- a/kosmos-testkit/src/main/kotlin/org/vorpal/kosmos/testing/QuaternionArbitraries.kt
+++ b/kosmos-testkit/src/main/kotlin/org/vorpal/kosmos/testing/QuaternionArbitraries.kt
@@ -6,7 +6,7 @@ import io.kotest.property.arbitrary.triple
 import io.kotest.property.arbitrary.bind
 import org.vorpal.kosmos.algebra.structures.instances.Quaternion
 import org.vorpal.kosmos.algebra.structures.instances.QuaternionAlgebras.normSq
-import org.vorpal.kosmos.algebra.structures.instances.QuaternionAlgebras.quaternion
+import org.vorpal.kosmos.algebra.structures.instances.quaternion
 
 object QuaternionArbitraries {
 

--- a/kosmos-testkit/src/main/kotlin/org/vorpal/kosmos/testing/RealArbitraries.kt
+++ b/kosmos-testkit/src/main/kotlin/org/vorpal/kosmos/testing/RealArbitraries.kt
@@ -5,7 +5,7 @@ import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.pair
 import io.kotest.property.arbitrary.triple
-import org.vorpal.kosmos.algebra.structures.instances.Real
+import org.vorpal.kosmos.core.math.Real
 import kotlin.math.abs
 
 object RealArbitraries {

--- a/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/laws/core/IndexFunctionLaws.kt
+++ b/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/laws/core/IndexFunctionLaws.kt
@@ -1,9 +1,9 @@
 package org.vorpal.kosmos.laws.core
 
-import arrow.core.identity
 import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import org.vorpal.kosmos.algebra.IndexFunction
+import org.vorpal.kosmos.core.Identity
 
 /**
  * Generic algebraic laws for any self-composable IndexFunction<T>.
@@ -70,7 +70,7 @@ object IndexFunctionLaws {
      */
     fun <T : IndexFunction<T>> rightIdentityLaw(ctx: Context<T>, n: Int = 5) {
         val m = ctx.sample()
-        m.flatMap { ctx.pure(::identity) }.run(n) shouldBe m.run(n)
+        m.flatMap { ctx.pure(Identity()) }.run(n) shouldBe m.run(n)
     }
 
     /**


### PR DESCRIPTION
Found bugs in `kosmos-testkit`. There is a lot of redundancy here and room for simplification, but after surviving law-hell and the fact that this compiles, that will become another issue to deal with on another day.