### PR TITLE
K81: Added permutation matrices and groups.

### DIFF
--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/algebra/morphisms/GroupMonomorphism.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/algebra/morphisms/GroupMonomorphism.kt
@@ -1,0 +1,25 @@
+package org.vorpal.kosmos.algebra.morphisms
+
+import org.vorpal.kosmos.algebra.structures.Group
+import org.vorpal.kosmos.categories.Monomorphism
+import org.vorpal.kosmos.core.Symbols
+import org.vorpal.kosmos.core.ops.UnaryOp
+
+/**
+ * A [GroupHomomorphism] which is also a [Monomorphism].
+ */
+interface GroupMonomorphism<A : Any, B : Any> :
+    GroupHomomorphism<A, B>,
+    Monomorphism<A, B> {
+        companion object {
+            fun <A : Any, B : Any> of(
+                domain: Group<A>,
+                codomain: Group<B>,
+                map: (A) -> B,
+            ): GroupMonomorphism<A, B> = object : GroupMonomorphism<A, B> {
+                override val domain = domain
+                override val codomain = codomain
+                override val map = UnaryOp(Symbols.PHI, map)
+            }
+        }
+}

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/algebra/structures/Subgroup.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/algebra/structures/Subgroup.kt
@@ -1,0 +1,71 @@
+package org.vorpal.kosmos.algebra.structures
+
+import org.vorpal.kosmos.algebra.morphisms.GroupMonomorphism
+import org.vorpal.kosmos.core.Identity
+import org.vorpal.kosmos.core.ops.BinOp
+import org.vorpal.kosmos.core.ops.Endo
+
+/**
+ * A [Subgroup] of a given [Group]. Contains a reference to the parent [Group] and a function to determine
+ * membership within this subgroup.
+ */
+interface Subgroup<A : Any> : Group<A> {
+    val parent: Group<A>
+    val isMember: (A) -> Boolean
+}
+
+class PredicateSubgroup<A : Any>(
+    override val parent: Group<A>,
+    override val isMember: (A) -> Boolean,
+) : Subgroup<A> {
+
+    init {
+        require(isMember(parent.identity)) {
+            "identity of a group is not a member of the subgroup"
+        }
+    }
+
+    private fun requireMember(x: A) {
+        require(isMember(x)) {
+            "tried to use $x as an element of a subgroup, yet it is not in the subgroup"
+        }
+    }
+
+    override val identity: A =
+        parent.identity
+
+    override val op: BinOp<A> =
+        BinOp(parent.op.symbol) { x, y ->
+            requireMember(x)
+            requireMember(y)
+            val z = parent.op(x, y)
+            requireMember(z)
+            z
+        }
+
+    override val inverse: Endo<A> =
+        Endo(parent.inverse.symbol) { x ->
+            requireMember(x)
+            val inv = parent.inverse(x)
+            requireMember(inv)
+            inv
+        }
+}
+
+fun <A : Any> Group<A>.subgroup(
+    isMember: (A) -> Boolean
+): Subgroup<A> =
+    PredicateSubgroup(
+        parent = this,
+        isMember = isMember
+    )
+
+/**
+ * Once we have a [Subgroup] of a [Group], then we inherently have a [GroupMonomorphism]
+ * from the [Subgroup] into the [Group].
+ */
+fun <A : Any> Subgroup<A>.inclusion(): GroupMonomorphism<A, A> = GroupMonomorphism.of(
+    domain = this,
+    codomain = parent,
+    map = Identity()
+)

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/bridge/PermutationBridge.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/bridge/PermutationBridge.kt
@@ -1,0 +1,83 @@
+package org.vorpal.kosmos.bridge
+
+import org.vorpal.kosmos.algebra.structures.Semiring
+import org.vorpal.kosmos.combinatorics.Permutation
+import org.vorpal.kosmos.core.Eq
+import org.vorpal.kosmos.core.finiteset.FiniteSet
+import org.vorpal.kosmos.functional.datastructures.Option
+import org.vorpal.kosmos.linear.values.DenseMat
+import org.vorpal.kosmos.linear.values.MatLike
+import org.vorpal.kosmos.linear.values.PermMat
+
+/**
+ * A functorial bridge between [Permutation] over the set `{0, ..., n-1}` and [PermMat].
+ */
+object PermutationBridge {
+    fun Permutation<Int>.toPermMat(): PermMat {
+        val n = domain.size
+        require(domain.toSet() == (0 until n).toSet()) {
+            "PermutationBridge requires domain = {0, ..., n-1}. Got: $domain"
+        }
+        return PermMat.of(IntArray(domain.size, this::get), copy = false)
+    }
+
+    fun PermMat.toPermutation(): Permutation<Int> =
+        Permutation.of(FiniteSet.ordered(0 until size),
+            (0 until size).associateWith { this[it] })
+
+    fun <A : Any> PermMat.toDenseMat(semiring: Semiring<A>): DenseMat<A> {
+        val n = size
+        val zero = semiring.add.identity
+        val one = semiring.mul.identity
+
+        return DenseMat.tabulate(n, n) { r, c ->
+            if (this[c] == r) one else zero
+        }
+    }
+
+    fun <A : Any> MatLike<A>.toPermMat(
+        zero: A,
+        one: A,
+        eq: Eq<A> = Eq.default()
+    ): Option<PermMat> {
+        if (rows != cols) return Option.None
+        val n = rows
+
+        val p = IntArray(n) { -1 }
+        val seenRow = BooleanArray(n)
+
+        var c = 0
+        while (c < n) {
+            var found = -1
+
+            var r = 0
+            while (r < n) {
+                val a = this[r, c]
+                if (!eq(a, zero) && !eq(a, one)) return Option.None
+                if (eq(a, one)) {
+                    if (found != -1) return Option.None
+                    found = r
+                }
+                r += 1
+            }
+
+            if (found == -1) return Option.None
+            if (seenRow[found]) return Option.None
+
+            seenRow[found] = true
+            p[c] = found
+            c += 1
+        }
+
+        return Option.Some(PermMat.of(p, copy = false))
+    }
+
+    fun <A : Any> MatLike<A>.toPermMat(
+        semiring: Semiring<A>,
+        eq: Eq<A> = Eq.default()
+    ): Option<PermMat> = toPermMat(
+        zero = semiring.add.identity,
+        one = semiring.mul.identity,
+        eq = eq
+    )
+}

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/bridge/PermutationMatrixIsomorphisms.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/bridge/PermutationMatrixIsomorphisms.kt
@@ -1,0 +1,203 @@
+package org.vorpal.kosmos.bridge
+
+import org.vorpal.kosmos.algebra.morphisms.GroupHomomorphism
+import org.vorpal.kosmos.algebra.morphisms.GroupIsomorphism
+import org.vorpal.kosmos.algebra.structures.Group
+import org.vorpal.kosmos.algebra.structures.Semiring
+import org.vorpal.kosmos.combinatorics.Permutation
+import org.vorpal.kosmos.combinatorics.instances.PermutationAlgebras
+import org.vorpal.kosmos.core.Eq
+import org.vorpal.kosmos.core.finiteset.FiniteSet
+import org.vorpal.kosmos.functional.datastructures.getOrElse
+import org.vorpal.kosmos.linear.instances.PermMatAlgebras
+import org.vorpal.kosmos.linear.instances.PermutationMatrixAlgebras
+import org.vorpal.kosmos.linear.values.DenseMat
+import org.vorpal.kosmos.linear.values.PermMat
+
+object PermutationMatrixIsomorphisms {
+
+    /**
+     * S_n as Permutation<Int>  ≅  S_n as PermMat
+     */
+    fun snPermutationToPermMat(n: Int): GroupIsomorphism<Permutation<Int>, PermMat> {
+        require(n >= 0) { "n must be nonnegative: $n" }
+
+        val domain = FiniteSet.ordered(0 until n)
+
+        // This must be the group whose op matches Permutation.andThen.
+        val snPerm: Group<Permutation<Int>> =
+            PermutationAlgebras.symmetricGroup(domain)
+
+        val snPermMat: Group<PermMat> =
+            PermMatAlgebras.symmetricGroup(n)
+
+        val forward = GroupHomomorphism.of(
+            domain = snPerm,
+            codomain = snPermMat
+        ) { p ->
+            with(PermutationBridge) { p.toPermMat() }
+        }
+
+        val backward = GroupHomomorphism.of(
+            domain = snPermMat,
+            codomain = snPerm
+        ) { pm ->
+            with(PermutationBridge) { pm.toPermutation() }
+        }
+
+        return GroupIsomorphism.of(forward, backward)
+    }
+
+    /**
+     * S_n as PermMat  ≅  S_n as DenseMat<A> (with the ∘ operation defined in PermutationMatrixAlgebras.symmetric)
+     */
+    fun <A : Any> snPermMatToDenseMat(
+        semiring: Semiring<A>,
+        n: Int,
+        eq: Eq<A> = Eq.default()
+    ): GroupIsomorphism<PermMat, DenseMat<A>> {
+        require(n >= 0) { "n must be nonnegative: $n" }
+
+        val snPermMat: Group<PermMat> =
+            PermMatAlgebras.symmetricGroup(n)
+
+        val snDense: Group<DenseMat<A>> =
+            PermutationMatrixAlgebras.symmetricGroup(semiring, n, eq)
+
+        val forward = GroupHomomorphism.of(
+            domain = snPermMat,
+            codomain = snDense
+        ) { pm ->
+            with(PermutationBridge) { pm.toDenseMat(semiring) }
+        }
+
+        val backward = GroupHomomorphism.of(
+            domain = snDense,
+            codomain = snPermMat
+        ) { m ->
+            // Since snDense is a group of permutation matrices (by construction),
+            // conversion should succeed, but we keep a safe fallback.
+            with(PermutationBridge) {
+                m.toPermMat(
+                    zero = semiring.add.identity,
+                    one = semiring.mul.identity,
+                    eq = eq
+                ).getOrElse {
+                    error("Unreachable: element of permutation-matrix group failed to decode.")
+                }
+            }
+        }
+
+        return GroupIsomorphism.of(forward, backward)
+    }
+
+    /**
+     * S_n as Permutation<Int>  ≅  S_n as DenseMat<A>
+     *
+     * Implemented as composition of the two isomorphisms above.
+     */
+    fun <A : Any> snPermutationToDenseMat(
+        semiring: Semiring<A>,
+        n: Int,
+        eq: Eq<A> = Eq.default()
+    ): GroupIsomorphism<Permutation<Int>, DenseMat<A>> {
+        val iso1 = snPermutationToPermMat(n)
+        val iso2 = snPermMatToDenseMat(semiring, n, eq)
+
+        val forward = iso1.forward andThen iso2.forward
+        val backward = iso2.backward andThen iso1.backward
+
+        return GroupIsomorphism.of(forward, backward)
+    }
+
+    /**
+     * A_n as Permutation<Int>  ≅  A_n as PermMat
+     */
+    fun anPermutationToPermMat(n: Int): GroupIsomorphism<Permutation<Int>, PermMat> {
+        require(n >= 0) { "n must be nonnegative: $n" }
+
+        val domain = FiniteSet.ordered(0 until n)
+
+        val anPerm =
+            PermutationAlgebras.alternatingSubgroup(domain) // returns Subgroup<Permutation<Int>>
+
+        val anPermMat =
+            PermMatAlgebras.alternatingSubgroup(n) // returns Subgroup<PermMat>
+
+        val forward = GroupHomomorphism.of(
+            domain = anPerm,
+            codomain = anPermMat
+        ) { p ->
+            with(PermutationBridge) { p.toPermMat() }
+        }
+
+        val backward = GroupHomomorphism.of(
+            domain = anPermMat,
+            codomain = anPerm
+        ) { pm ->
+            with(PermutationBridge) { pm.toPermutation() }
+        }
+
+        return GroupIsomorphism.of(forward, backward)
+    }
+
+    /**
+     * A_n as PermMat  ≅  A_n as DenseMat<A>
+     */
+    fun <A : Any> anPermMatToDenseMat(
+        semiring: Semiring<A>,
+        n: Int,
+        eq: Eq<A> = Eq.default()
+    ): GroupIsomorphism<PermMat, DenseMat<A>> {
+        require(n >= 0) { "n must be nonnegative: $n" }
+
+        val anPermMat =
+            PermMatAlgebras.alternatingSubgroup(n)
+
+        val anDense =
+            PermutationMatrixAlgebras.alternatingSubgroup(semiring, n, eq)
+
+        val forward = GroupHomomorphism.of(
+            domain = anPermMat,
+            codomain = anDense
+        ) { pm ->
+            with(PermutationBridge) { pm.toDenseMat(semiring) }
+        }
+
+        val backward = GroupHomomorphism.of(
+            domain = anDense,
+            codomain = anPermMat
+        ) { m ->
+            with(PermutationBridge) {
+                m.toPermMat(
+                    zero = semiring.add.identity,
+                    one = semiring.mul.identity,
+                    eq = eq
+                ).getOrElse {
+                    error("Unreachable: element of alternating permutation-matrix subgroup failed to decode.")
+                }
+            }
+        }
+
+        return GroupIsomorphism.of(forward, backward)
+    }
+
+    /**
+     * A_n as Permutation<Int>  ≅  A_n as DenseMat<A>
+     *
+     * Implemented as composition of the two isomorphisms above.
+     */
+    fun <A : Any> anPermutationToDenseMat(
+        semiring: Semiring<A>,
+        n: Int,
+        eq: Eq<A> = Eq.default()
+    ): GroupIsomorphism<Permutation<Int>, DenseMat<A>> {
+        val iso1 = anPermutationToPermMat(n)
+        val iso2 = anPermMatToDenseMat(semiring, n, eq)
+
+        val forward = iso1.forward andThen iso2.forward
+        val backward = iso2.backward andThen iso1.backward
+
+        return GroupIsomorphism.of(forward, backward)
+    }
+}

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/categories/Morphism.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/categories/Morphism.kt
@@ -172,33 +172,3 @@ fun <A> Automorphism<A>.cycleDecomposition(domain: FiniteSet<A>): List<List<A>> 
 
     return cycles
 }
-
-
-
-// TODO: *** REMOVE THESE EXAMPLES ***
-val intAutoGroup: Group<Automorphism<Int>> = Group.of(
-    identity = Automorphism.id(),
-    op = BinOp(Symbols.COMPOSE, Automorphism<Int>::andThen),
-    inverse = Endo(Symbols.INVERSE, Automorphism<Int>::inverse)
-)
-
-object CategoryOfMorphisms {
-    fun <A> id(): Morphism<A, A> = Morphism.id()
-    fun <A, B, C> compose(f: Morphism<B, C>, g: Morphism<A, B>): Morphism<A, C> =
-        g andThen f
-}
-
-class OneObjectCategory<A>(
-    private val group: Group<Automorphism<A>>,
-    private val obj: A
-) : Category<A, Automorphism<A>> {
-    override val compose: (Automorphism<A>, Automorphism<A>) -> Automorphism<A> = {f, g -> f andThen g}
-    override val id: (A) -> Automorphism<A> = { Automorphism.id() }
-    override fun toString(): String = "Category(Obj=$obj, Morphisms=Automorphisms($obj))"
-}
-
-fun main() {
-    val autInt = Automorphism.of<Int>({it + 3}, {it - 3})
-    println(autInt.apply(10))
-    println(autInt.inverse().apply(10))
-}

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/combinatorics/instances/PermutationAlgebras.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/combinatorics/instances/PermutationAlgebras.kt
@@ -1,0 +1,29 @@
+package org.vorpal.kosmos.combinatorics.instances
+
+import org.vorpal.kosmos.algebra.structures.Group
+import org.vorpal.kosmos.algebra.structures.Subgroup
+import org.vorpal.kosmos.algebra.structures.subgroup
+import org.vorpal.kosmos.combinatorics.Permutation
+import org.vorpal.kosmos.core.Symbols
+import org.vorpal.kosmos.core.finiteset.FiniteSet
+import org.vorpal.kosmos.core.ops.BinOp
+import org.vorpal.kosmos.core.ops.Endo
+
+object PermutationAlgebras {
+    fun <A : Any> symmetricGroup(domain: FiniteSet<A>): Group<Permutation<A>> = Group.of(
+        identity = Permutation.identity(domain),
+        op = BinOp(Symbols.OPEN_CIRCLE) { x, y -> x andThen y},
+        inverse = Endo(Symbols.INVERSE, Permutation<A>::inverse)
+    )
+
+    fun <A : Any> alternatingSubgroup(domain: FiniteSet<A>): Subgroup<Permutation<A>> =
+        symmetricGroup(domain).subgroup { it.sign() == 1 }
+
+    fun symmetricGroup(n: Int): Group<Permutation<Int>> {
+        require(n >= 0) { "Group must be non-negative: $n" }
+        return symmetricGroup(FiniteSet.ordered(0 until n))
+    }
+
+    fun alternatingSubgroup(n: Int): Subgroup<Permutation<Int>> =
+        symmetricGroup(n).subgroup { it.sign() == 1 }
+}

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/functional/datastructures/Option.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/functional/datastructures/Option.kt
@@ -46,6 +46,11 @@ inline fun <A, B> Option<A>.fold(onNone: () -> B, onSome: (A) -> B): B = when (t
 fun <A, B> Option<A>.zip(other: Option<B>): Option<Pair<A, B>> =
     flatMap { a -> other.map { b -> a to b } }
 
+fun <A> Option<A>.getOrElse(default: A): A = when (this) {
+    is Option.Some -> value
+    is Option.None -> default
+}
+
 fun <A> Option<A>.getOrElse(default: () -> A): A = when (this) {
     is Option.Some -> value
     is Option.None -> default()

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/linear/instances/PermMatAlgebras.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/linear/instances/PermMatAlgebras.kt
@@ -1,0 +1,30 @@
+package org.vorpal.kosmos.linear.instances
+
+import org.vorpal.kosmos.algebra.structures.Group
+import org.vorpal.kosmos.algebra.structures.Subgroup
+import org.vorpal.kosmos.algebra.structures.subgroup
+import org.vorpal.kosmos.core.Symbols
+import org.vorpal.kosmos.core.ops.BinOp
+import org.vorpal.kosmos.core.ops.Endo
+import org.vorpal.kosmos.linear.values.PermMat
+
+object PermMatAlgebras {
+    /**
+     * Create a group of `n×n` [PermMat] representing the (compressed) matrix representation of the `S_n`.
+     */
+    fun symmetricGroup(n: Int): Group<PermMat> {
+        require(n >= 0) { "n must be nonnegative: $n" }
+
+        return Group.of(
+            identity = PermMat.identity(n),
+            op = BinOp(Symbols.OPEN_CIRCLE, PermMat::andThen),
+            inverse = Endo(Symbols.INVERSE, PermMat::inverse)
+        )
+    }
+
+    /**
+     * Create the subgroup of `n×n` [PermMat] representing the (compressed) matrix subgroup `A_n` of `S_n`.
+     */
+    fun alternatingSubgroup(n: Int): Subgroup<PermMat> =
+        symmetricGroup(n).subgroup(PermMat::isEven)
+}

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/linear/instances/PermutationMatrixAlgebras.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/linear/instances/PermutationMatrixAlgebras.kt
@@ -1,0 +1,125 @@
+package org.vorpal.kosmos.linear.instances
+
+import org.vorpal.kosmos.algebra.structures.Group
+import org.vorpal.kosmos.algebra.structures.Subgroup
+import org.vorpal.kosmos.algebra.structures.Semiring
+import org.vorpal.kosmos.algebra.structures.subgroup
+import org.vorpal.kosmos.bridge.PermutationBridge.toPermMat
+import org.vorpal.kosmos.core.Eq
+import org.vorpal.kosmos.core.Symbols
+import org.vorpal.kosmos.core.ops.BinOp
+import org.vorpal.kosmos.core.ops.Endo
+import org.vorpal.kosmos.functional.datastructures.getOrElse
+import org.vorpal.kosmos.functional.datastructures.map
+import org.vorpal.kosmos.linear.values.DenseMat
+import org.vorpal.kosmos.linear.values.MatLike
+import org.vorpal.kosmos.linear.values.PermMat
+import org.vorpal.kosmos.linear.views.transposeView
+
+object PermutationMatrixAlgebras {
+
+    /**
+     * Create a group of `n×n` [DenseMat] representing the matrix representation of the `S_n` over a given
+     * [Semiring].
+     *
+     * Unlike [PermMatAlgebras.symmetric], it uses full [DenseMat] instead of the faster [PermMat].
+     *
+     * Note: the group operation here is composition (∘), implemented as reversed
+     * matrix multiplication:
+     * ```
+     * X ∘ Y := Y * X
+     * ```
+     * This is chosen so that the natural map `p ↦ M_p` is a `GroupHomomorphism`
+     * that aligns with `Permutation.andThen`:
+     * ```
+     * (p andThen q)(x) = q(p(x)).
+     * ```
+     *
+     * If you want the usual linear-algebra group operation, use standard matrix
+     * multiplication (*) on permutation matrices instead.
+     */
+    fun <A : Any> symmetricGroup(
+        semiring: Semiring<A>,
+        n: Int,
+        eq: Eq<A> = Eq.default()
+    ): Group<DenseMat<A>> {
+        require(n >= 0) { "n must be nonnegative: $n" }
+
+        val zero = semiring.add.identity
+        val one = semiring.mul.identity
+
+        require(!eq(zero, one)) { "Permutation matrices require 0 != 1." }
+
+        fun requirePermMat(m: MatLike<A>) {
+            require(m.rows == n) { "Expected $n rows, got ${m.rows}." }
+            require(m.cols == n) { "Expected $n cols, got ${m.cols}." }
+            require(DenseMatKernel.isPermutationMatrix(m, zero, one, eq)) {
+                "Not a permutation matrix."
+            }
+        }
+
+        return Group.of(
+            identity = DenseMatKernel.identity(semiring, n),
+
+            // Composition (∘) aligned with Permutation.andThen:
+            // X ∘ Y := Y * X  (reverse standard matMul)
+            op = BinOp(Symbols.OPEN_CIRCLE) { x, y ->
+                requirePermMat(x)
+                requirePermMat(y)
+                DenseMatKernel.matMul(semiring, y, x)
+            },
+
+            // Inverse of permutation matrix is transpose.
+            inverse = Endo(Symbols.INVERSE) { x ->
+                requirePermMat(x)
+                DenseMatKernel.copy(x.transposeView())
+            }
+        )
+    }
+
+    /**
+     * Create the subgroup of `n×n` [DenseMat] representing the subgroup `A_n` of `S_n` over a given [Semiring].
+     *
+     * Unlike [PermMatAlgebras.alternating], it uses full [DenseMat] instead of the faster [PermMat].
+     *
+     * Note: the group operation here is composition (∘), implemented as reversed
+     * matrix multiplication:
+     * ```
+     * X ∘ Y := Y * X
+     * ```
+     * This is chosen so that the natural map `p ↦ M_p` is a `GroupHomomorphism`
+     * that aligns with `Permutation.andThen`:
+     * ```
+     * (p andThen q)(x) = q(p(x)).
+     * ```
+     *
+     * If you want the usual linear-algebra group operation, use standard matrix
+     * multiplication (*) on permutation matrices instead.
+     */
+    fun <A : Any> alternatingSubgroup(
+        semiring: Semiring<A>,
+        n: Int,
+        eq: Eq<A> = Eq.default()
+    ): Subgroup<DenseMat<A>> {
+        val g = symmetricGroup(semiring, n, eq)
+
+        val zero = semiring.add.identity
+        val one = semiring.mul.identity
+
+        return g.subgroup { m ->
+            isEvenPermutationMatrix(m, zero, one, eq)
+        }
+    }
+
+    /**
+     * Returns true iff m is a permutation matrix with even parity.
+     * Convention: for each column c, find unique row r with m[r,c] == 1, then p[c] = r.
+     * Parity is even iff (n - numberOfCycles(p)) is even.
+     */
+    private fun <A : Any> isEvenPermutationMatrix(
+        m: MatLike<A>,
+        zero: A,
+        one: A,
+        eq: Eq<A>
+    ): Boolean = m.toPermMat(zero, one, eq).map(PermMat::isEven).getOrElse(false)
+}

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/linear/values/PermMat.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/linear/values/PermMat.kt
@@ -1,0 +1,113 @@
+package org.vorpal.kosmos.linear.values
+
+/**
+ * A compact representation of a permutation matrix that implements [MatLike] so that it can be used with other
+ * matrix operations, but is implemented with an [IntArray] [p] where `p[c] = p(c)`, i.e. the image of an element `c`
+ * in the range `[0,n)` is `p[c]`.
+ */
+class PermMat private constructor(
+    private val p: IntArray
+) : MatLike<Int> {
+
+    val size: Int
+        get() = p.size
+
+    override val rows: Int
+        get() = p.size
+
+    override val cols: Int
+        get() = p.size
+
+    operator fun get(r: Int): Int =
+        p[r]
+
+    override operator fun get(r: Int, c: Int): Int =
+        if (p[c] == r) 1 else 0
+
+    /** (this andThen other)(c) = other(this(c)) */
+    infix fun andThen(other: PermMat): PermMat {
+        val n = p.size
+        require(other.p.size == n) { "size mismatch" }
+
+        val out = IntArray(n)
+
+        var c = 0
+        while (c < n) {
+            out[c] = other[this[c]]
+            c += 1
+        }
+
+        return PermMat(out)
+    }
+
+    /** (this compose other)(c) = this(other(c)) */
+    infix fun compose(other: PermMat): PermMat =
+        other andThen this
+
+    fun inverse(): PermMat {
+        val n = p.size
+        val inv = IntArray(n) { -1 }
+
+        var c = 0
+        while (c < n) {
+            val r = p[c]
+            require(r in 0 until n) { "invalid value p[$c] = $r" }
+            require(inv[r] == -1) { "duplicate image $r" }
+            inv[r] = c
+            c += 1
+        }
+
+        return PermMat(inv)
+    }
+
+    fun isEven(): Boolean {
+        val n = p.size
+        val visited = BooleanArray(n)
+        var cycles = 0
+
+        var v = 0
+        while (v < n) {
+            if (!visited[v]) {
+                cycles += 1
+                var cur = v
+                while (!visited[cur]) {
+                    visited[cur] = true
+                    cur = p[cur]
+                }
+            }
+            v += 1
+        }
+
+        return ((n - cycles) and 1) == 0
+    }
+
+    fun toIntArray(): IntArray =
+        p.copyOf()
+
+    companion object {
+        fun identity(n: Int): PermMat {
+            require(n >= 0) { "n must be nonnegative" }
+            return PermMat(IntArray(n) { it })
+        }
+
+        fun of(p: IntArray, copy: Boolean = true): PermMat {
+            val owned =
+                if (copy) p.copyOf()
+                else p
+
+            val n = owned.size
+            val seen = BooleanArray(n)
+
+            var c = 0
+            while (c < n) {
+                val r = owned[c]
+                require(r in 0 until n) { "invalid value p[$c] = $r" }
+                require(!seen[r]) { "duplicate image $r" }
+                seen[r] = true
+                c += 1
+            }
+
+            return PermMat(owned)
+        }
+    }
+}


### PR DESCRIPTION
Added the following:
- `GroupMonomorphism`s.
- `Subgroup` and an easy way to pass a membership function to a `Group` to determine membership in the `Subgroup`.
- `PermMat`, which is another (square) implementation of `MatLike<Int>`, which represents a permutation over `0, ... , n-1` using a compact `IntArray` instead of a full `nxn` matrix, but that still acts like an `nxn` matrix while only using `O(n)` memory instead of `O(n^2)` memory.
- `Group` and alternating `Subgroup` over `Permutation`, `PermMat`, and `DenseMat` (where the elements are permutation matrices).
- Bridge between `Permutation` and `PermMat`.
- Isomorphisms between all groups and subgroups.