### PR TITLE
K153: Cleaned up QuadraticRank2MatrixEmbedding.

### DIFF
--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/algebra/quadratic/QuadraticRank2MatrixEmbeddings.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/algebra/quadratic/QuadraticRank2MatrixEmbeddings.kt
@@ -10,48 +10,6 @@ import org.vorpal.kosmos.linear.values.DenseMat
 import java.math.BigInteger
 
 /**
- * Given a rank-2 `ℤ`-basis `{1, w}` with quadratic relation
- * ```text
- * w^2 = s + tw,
- * ```
- * construct the corresponding matrix embedding into `M_2(ℤ)`.
- *
- * For an element written as
- * ```text
- * a * 1 + b * w = a + bw
- * ```
- * the associated matrix is
- * ```text
- * [a       sb]
- * [b   a + tb]
- * ```
- * whose columns are the coordinates of `(a + bw) * 1` and `(a + bw) * w`
- * relative to the basis `{1, w}`.
- *
- * The [coeffs] function must extract the coefficient pair `(a, b)` from an
- * element of the domain.
- */
-fun <A : Any> quadraticRank2ZMatrixEmbedding(
-    domain: Ring<A>,
-    s: BigInteger,
-    t: BigInteger,
-    coeffs: (A) -> Pair<BigInteger, BigInteger>
-): RingMonomorphism<A, DenseMat<BigInteger>> =
-    RingMonomorphism.of(
-        domain = domain,
-        codomain = DenseMatAlgebras.DenseMatRing(IntegerAlgebras.IntegerCommutativeRing, 2),
-        map = UnaryOp { z ->
-            val (a, b) = coeffs(z)
-            DenseMat.ofRows(
-                listOf(
-                    listOf(a, s * b),
-                    listOf(b, a + t * b)
-                )
-            )
-        }
-    )
-
-/**
  * Given a rank-2 `R`-basis `{1, w}` with quadratic relation
  * ```text
  * w^2 = s + tw,


### PR DESCRIPTION
Removed the explicit (now unused) integer version.