### PR TITLE
K179: Implemented Word and Words and fixed bugs in Poset.

### DIFF
--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/algebra/free/Word.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/algebra/free/Word.kt
@@ -1,0 +1,36 @@
+package org.vorpal.kosmos.algebra.free
+
+/**
+ * A finite word over an alphabet of letters of type [A].
+ */
+data class Word<A : Any>(
+    val letters: List<A>
+) {
+    val length: Int
+        get() = letters.size
+
+    val isEmpty: Boolean
+        get() = letters.isEmpty()
+
+    infix fun concatenate(other: Word<A>): Word<A> =
+        Word(letters + other.letters)
+
+    fun reversed(): Word<A> =
+        Word(letters.reversed())
+
+    fun splitAt(pos: Int): Pair<Word<A>, Word<A>> {
+        require(pos in 0..length) {
+            "Position must be between 0 and $length, got: $pos"
+        }
+
+        return Word(letters.subList(0, pos)) to Word(letters.subList(pos, length))
+    }
+
+    fun deconcatenations(): List<Pair<Word<A>, Word<A>>> =
+        (0..length).map(::splitAt)
+
+    companion object {
+        fun <A : Any> empty(): Word<A> =
+            Word(emptyList())
+    }
+}

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/algebra/free/Words.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/algebra/free/Words.kt
@@ -1,0 +1,16 @@
+package org.vorpal.kosmos.algebra.free
+
+import org.vorpal.kosmos.algebra.structures.Monoid
+import org.vorpal.kosmos.core.ops.BinOp
+
+object Words {
+    /**
+     * Creates the free monoid on alphabet [A], whose elements are finite words
+     * and whose operation is concatenation.
+     */
+    fun <A : Any> monoid(): Monoid<Word<A>> =
+        Monoid.of(
+            identity = Word.empty(),
+            op = BinOp { left, right -> left concatenate right }
+        )
+}

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/core/Symbols.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/core/Symbols.kt
@@ -49,6 +49,7 @@ object Symbols {
     const val CUBE_ROOT = "∛"
     const val CUBED = "³"
     const val DAGGER = "†"
+    const val DELTA = "δ"
     const val DIAMOND = "⋄"
     const val DIAMOND_BIG = "◇"
     const val DIVISION = "÷"
@@ -110,6 +111,7 @@ object Symbols {
     const val O_TIMES = "⊗"
     const val O_TIMES_BIG = "⨂"
     const val OMEGA = "ω"
+    const val OMEGA_UPPER = "Ω"
     const val ONE = "1"
     const val OPEN_CIRCLE = "∘"
     const val PARTIAL = "∂"
@@ -151,6 +153,8 @@ object Symbols {
     const val SUM = "∑"
     const val TENSOR = "⊗"
     const val THEREFORE = "∴"
+    const val THETA = "θ"
+    const val THETA_SCRIPT= "ϑ"
     const val THREE_SUB = "₃"
     const val TIMES = "×"
     const val TOMBSTONE = "▯"
@@ -175,7 +179,6 @@ object Symbols {
     const val DIV_RIGHT = SLASH
     const val HADAMARD = O_DOT
     const val INJECTION = MAPS_INTO
-    const val KRONECKER = O_TIMES
     const val LEXICOGRAPHIC = BIG_DOT
     const val PROJECTION = PI
     const val SET_MINUS = BACKSLASH

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/core/relations/Relation.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/core/relations/Relation.kt
@@ -82,14 +82,14 @@ interface Preorder<A : Any> : Reflexive<A>, Transitive<A>, HasRelation<A> {
 /** Poset: preorder + antisymmetry. */
 interface Poset<A : Any> : Preorder<A>, Antisymmetric<A> {
     val ge: Relation<A>
-        get() = le.converse(Symbols.GREATER_THAN)
+        get() = lt.converse(Symbols.GREATER_THAN_EQ)
 
     /** Strict part: a < b  :⇔  a ≤ b ∧ ¬(b ≤ a). */
     val lt: Relation<A>
         get() = Relation(Symbols.LESS_THAN) { a, b -> le(a, b) && !le(b, a) }
 
     val gt: Relation<A>
-        get() = lt.converse(Symbols.GREATER_THAN_EQ)
+        get() = le.converse(Symbols.GREATER_THAN)
 
     fun dual(): Poset<A> =
         of(le.converse())


### PR DESCRIPTION
This is the start of shuffle algebra implementation: we implement `Word<A>` and `Words`, which creates a `Monoid<Word<A>>`, i.e. a free monoid on `A`.

Also fixes bugs in `Poset`.