### PR TITLE
K170: Added Fano plane orientation for octonions and octonion tests.

### DIFF
--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/combinatorics/FanoPlane.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/combinatorics/FanoPlane.kt
@@ -27,6 +27,9 @@ object FanoPlane : FiniteProjectivePlane<Int> {
             val s = FiniteSet.of(a, b, c)
             s.cartesianProduct(s).mapNotNull { if (it.first == it.second) null else it }
         }
+
+        fun toFiniteSet() = FiniteSet.unordered(a, b, c)
+        fun toList() = listOf(a, b, c)
     }
 
     val lines: FiniteSet<Line> = FiniteSet.of(

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionFanoOrientation.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionFanoOrientation.kt
@@ -1,0 +1,33 @@
+package org.vorpal.kosmos.hypercomplex.octonion
+
+import org.vorpal.kosmos.combinatorics.FanoPlane
+import org.vorpal.kosmos.core.finiteset.FiniteSet
+import org.vorpal.kosmos.core.finiteset.toUnorderedFiniteSet
+
+/**
+ * A Fano plane where the lines are all oriented, used to dictate the multiplication table of the octonions.
+ */
+data class OctonionFanoOrientation(
+    val lines: FiniteSet<OrientedFanoLine>
+) {
+    init {
+        require(lines.size == 7) {
+            "There must be exactly 7 lines in the Fano plane."
+        }
+
+        val underlying = lines.map { it.toFiniteSet() }.toUnorderedFiniteSet()
+        val expected = FanoPlane.lines.map { it.toFiniteSet() }.toUnorderedFiniteSet()
+        require(underlying == expected) {
+            "The oriented lines must match the underlying Fano plane lines."
+        }
+    }
+
+    fun orientedLineThrough(i: Int, j: Int): OrientedFanoLine =
+        lines.firstOrNull { i in it && j in it } ?: error("No line through $i and $j")
+
+    fun thirdPoint(i: Int, j: Int): Int =
+        orientedLineThrough(i, j).thirdPoint(i, j)
+
+    fun sign(i: Int, j: Int): Int =
+        orientedLineThrough(i, j).signOfOrderedPair(i, j)
+}

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionFanoOrientations.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionFanoOrientations.kt
@@ -1,0 +1,67 @@
+package org.vorpal.kosmos.hypercomplex.octonion
+
+import org.vorpal.kosmos.combinatorics.FanoPlane
+import org.vorpal.kosmos.core.finiteset.toUnorderedFiniteSet
+
+/**
+ * This is the most important part of the Fano plane octonion classes:
+ *
+ * We derive the orientation of the Fano plane lines from the actial octonion multiplication, and not
+ * from memory or a diagram.
+ */
+object OctonionFanoOrientations {
+    private val ring = OctonionAlgebras.OctonionDivisionAlgebraReal
+
+    private val basis: Map<Int, Octonion> =
+        (1..7).associateWith { ring.basisMap.getValue(it) }
+
+    private fun neg(o: Octonion): Octonion =
+        ring.add.inverse(o)
+
+    /**
+     * Returns `(k, sign)` where `e_i * e_j = sign * e_k`.
+     */
+    private fun signedBasisProduct(i: Int, j: Int): Pair<Int, Int> {
+        require(i in 1..7 && j in 1..7 && i != j) {
+            "Basis indices must be distinct elements of {1, ..., 7}: got $i and $j."
+        }
+
+        val eq = OctonionAlgebras.eqOctonionStrict
+        val product = ring.mul(basis.getValue(i), basis.getValue(j))
+
+        return (1..7).firstNotNullOfOrNull { k ->
+            val ek = basis.getValue(k)
+            when {
+                eq(product, ek) -> k to 1
+                eq(product, neg(ek)) -> k to -1
+                else -> null
+            }
+        } ?: error("Product of e$i and e$j was not ±ek for any k in {1, ..., 7}.")
+    }
+
+    fun deriveFromCurrentBasis(): OctonionFanoOrientation {
+        val orientedLines = FanoPlane.lines.map { line ->
+            val points = line.toList()
+
+            val candidates = listOf(
+                points[0] to points[1],
+                points[0] to points[2],
+                points[1] to points[2]
+            )
+
+            val triple = candidates.firstNotNullOfOrNull { (i, j) ->
+                val (k, sign) = signedBasisProduct(i, j)
+                if (sign == 1 && k in points) Triple(i, j, k)
+                else null
+            } ?: error("Could not orient Fano line $points from basis multiplication.")
+
+            OrientedFanoLine(
+                a = triple.first,
+                b = triple.second,
+                c = triple.third
+            )
+        }.toUnorderedFiniteSet()
+
+        return OctonionFanoOrientation(orientedLines)
+    }
+}

--- a/kosmos-core/src/main/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OrientedFanoLine.kt
+++ b/kosmos-core/src/main/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OrientedFanoLine.kt
@@ -1,0 +1,70 @@
+package org.vorpal.kosmos.hypercomplex.octonion
+
+import org.vorpal.kosmos.core.finiteset.FiniteSet
+
+/**
+ * A line in the Fano plane that has an orientation associated with it, i.e. `(a, b, c)`.
+ */
+data class OrientedFanoLine(
+    val a: Int,
+    val b: Int,
+    val c: Int
+) {
+    init {
+        require(setOf(a, b, c).size == 3) {
+            "An oriented Fano line must contain exactly three distinct elements: got $this."
+        }
+        require(a in 1..7 && b in 1..7 && c in 1..7) {
+            "An oriented Fano line must contain elements from the set {1, 2, 3, 4, 5, 6, 7}: got $this."
+        }
+    }
+
+    /**
+     * Returns `true` iff the point `i` is contained in the line.
+     */
+    operator fun contains(i: Int): Boolean =
+        i == a || i == b || i == c
+
+    /**
+     * Make sure that the points `i` and `j` are distinct and contained in the line.
+     */
+    private fun checkPoints(i: Int, j: Int) {
+        require(i != j) {
+            "Points must be distinct: both points were $i."
+        }
+        require(i in this && j in this) {
+            "Points must be contained in the line: got $i and $j, line is $this."
+        }
+    }
+
+    /**
+     * Given two points on this line, returns the third point.
+     */
+    fun thirdPoint(i: Int, j: Int): Int {
+        checkPoints(i, j)
+        return when {
+            i != a && j != a -> a
+            i != b && j != b -> b
+            else -> c
+        }
+    }
+
+    /**
+     * Returns `+1` if `(i,j)` is positively oriented on this cyclic line, and `-1` if `(i,j)` is negatively oriented.
+     */
+    fun signOfOrderedPair(i: Int, j: Int): Int {
+        checkPoints(i, j)
+        return when (i to j) {
+            (a to b) -> 1
+            (b to c) -> 1
+            (c to a) -> 1
+            else -> -1
+        }
+    }
+
+    fun toFiniteSet() =
+        FiniteSet.unordered(a, b, c)
+
+    override fun toString(): String =
+        "($a, $b, $c)"
+}

--- a/kosmos-laws/src/main/kotlin/org/vorpal/kosmos/laws/property/MoufangLaw.kt
+++ b/kosmos-laws/src/main/kotlin/org/vorpal/kosmos/laws/property/MoufangLaw.kt
@@ -85,7 +85,10 @@ class RightMoufangLaw<A: Any>(
 /**
  * Middle Moufang:
  *
- *     (x ⋆ y) ⋆ (z ⋆ x) = x ⋆ (y ⋆ (z ⋆ x))
+ *     (x ⋆ y) ⋆ (z ⋆ x) = x ⋆ ((y ⋆ z) ⋆ x)
+ *
+ * The right-hand side is the flexible expression `x ⋆ (y ⋆ z) ⋆ x`; since alternative algebras are
+ * flexible, `x ⋆ ((y ⋆ z) ⋆ x) = (x ⋆ (y ⋆ z)) ⋆ x`, so the parenthesization chosen here is immaterial.
  */
 class MiddleMoufangLaw<A: Any>(
     override val op: BinOp<A>,
@@ -98,8 +101,9 @@ class MiddleMoufangLaw<A: Any>(
     override suspend fun test() {
         checkAll(TestingLaw.arbTriple(arb)) { (x, y, z) ->
             val zx = op(z, x)
+            val yz = op(y, z)
             val lhs = op(op(x, y), zx)
-            val rhs = op(x, op(y, zx))
+            val rhs = op(x, op(yz, x))
 
             withClue(failMsg("middle", x, y, z, lhs, rhs)) {
                 check(eq(lhs, rhs))

--- a/kosmos-testkit/src/main/kotlin/org/vorpal/kosmos/hypercomplex/octonion/ArbOctonion.kt
+++ b/kosmos-testkit/src/main/kotlin/org/vorpal/kosmos/hypercomplex/octonion/ArbOctonion.kt
@@ -10,7 +10,7 @@ object ArbOctonion {
     private val octonions = OctonionAlgebras.OctonionDivisionAlgebraReal
 
     val octonion: Arb<Octonion> =
-        Arb.Companion.bind(
+        Arb.bind(
             ArbReal.smallReal,
             ArbReal.smallReal,
             ArbReal.smallReal,
@@ -30,8 +30,8 @@ object ArbOctonion {
         }
 
     val octonionTriple: Arb<Triple<Octonion, Octonion, Octonion>> =
-        Arb.Companion.triple(octonion, octonion, octonion)
+        Arb.triple(octonion, octonion, octonion)
 
     val reciprocalTriple: Arb<Triple<Octonion, Octonion, Octonion>> =
-        Arb.Companion.triple(reciprocalSafeOctonion, reciprocalSafeOctonion, reciprocalSafeOctonion)
+        Arb.triple(reciprocalSafeOctonion, reciprocalSafeOctonion, reciprocalSafeOctonion)
 }

--- a/kosmos-testkit/src/main/kotlin/org/vorpal/kosmos/hypercomplex/quaternion/ArbQuaternion.kt
+++ b/kosmos-testkit/src/main/kotlin/org/vorpal/kosmos/hypercomplex/quaternion/ArbQuaternion.kt
@@ -12,7 +12,7 @@ object ArbQuaternion {
      * Generic quaternion with reasonably small components.
      */
     val quaternion: Arb<Quaternion> =
-        Arb.Companion.bind(
+        Arb.bind(
             ArbReal.smallReal,
             ArbReal.smallReal,
             ArbReal.smallReal,
@@ -31,8 +31,8 @@ object ArbQuaternion {
         }
 
     val quaternionTriple: Arb<Triple<Quaternion, Quaternion, Quaternion>> =
-        Arb.Companion.triple(quaternion, quaternion, quaternion)
+        Arb.triple(quaternion, quaternion, quaternion)
 
     val reciprocalTriple: Arb<Triple<Quaternion, Quaternion, Quaternion>> =
-        Arb.Companion.triple(reciprocalSafeQuaternion, reciprocalSafeQuaternion, reciprocalSafeQuaternion)
+        Arb.triple(reciprocalSafeQuaternion, reciprocalSafeQuaternion, reciprocalSafeQuaternion)
 }

--- a/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionAlternativitySpec.kt
+++ b/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionAlternativitySpec.kt
@@ -1,0 +1,36 @@
+package org.vorpal.kosmos.hypercomplex.octonion
+
+import io.kotest.core.spec.style.StringSpec
+import org.vorpal.kosmos.laws.property.AlternativityLaw
+import org.vorpal.kosmos.laws.property.MoufangLaw
+
+/**
+ * Confirms the *weak* associativity that [OctonionAlgebras.OctonionDivisionAlgebraReal] DOES satisfy,
+ * complementing [OctonionNonAssociativitySpec] (which shows it is not fully associative).
+ *
+ * - [AlternativityLaw]: `x(xy) = (xx)y` and `(yx)x = y(xx)`. By Artin's theorem this is equivalent to
+ *   any two elements generating an associative subalgebra — the precise sense in which 𝕆 is "almost"
+ *   associative.
+ * - [MoufangLaw]: the three Moufang identities, which are strictly stronger than alternativity and
+ *   hold in every alternative algebra.
+ *
+ * These are bare [org.vorpal.kosmos.laws.TestingLaw]s rather than a bundled suite, so we invoke
+ * `.test()` directly. We use the plain octonion generator (no reciprocal needed) and the approximate
+ * octonion equality, since these identities are exact algebraically but evaluated in floating point.
+ */
+object OctonionAlternativitySpec : StringSpec({
+
+    val ring = OctonionAlgebras.OctonionDivisionAlgebraReal
+    val op = ring.mul.op
+    val arb = ArbOctonion.octonion
+    val eq = OctonionAlgebras.eqOctonion
+    val pr = OctonionAlgebras.printableOctonionPretty
+
+    "octonion multiplication is alternative: x(xy) = (xx)y and (yx)x = y(xx)" {
+        AlternativityLaw(op, arb, eq, pr).test()
+    }
+
+    "octonion multiplication satisfies the Moufang identities" {
+        MoufangLaw(op, arb, eq, pr).test()
+    }
+})

--- a/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionFanoOrientationSpec.kt
+++ b/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionFanoOrientationSpec.kt
@@ -1,0 +1,79 @@
+package org.vorpal.kosmos.hypercomplex.octonion
+
+import io.kotest.assertions.fail
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import org.vorpal.kosmos.combinatorics.FanoPlane
+import org.vorpal.kosmos.core.finiteset.toUnorderedFiniteSet
+
+/**
+ * Verifies that [OctonionFanoOrientations.deriveFromCurrentBasis] recovers the *signed* Fano-line
+ * orientation that is actually used by [OctonionAlgebras.OctonionDivisionAlgebraReal], rather than
+ * one taken from memory or a diagram.
+ *
+ * The orientation derived from the multiplication is then checked against the multiplication itself,
+ * including the [OctonionFanoOrientation.sign]/[OctonionFanoOrientation.thirdPoint] API over every
+ * ordered pair of distinct basis indices.
+ *
+ * NOTE: octonion products are compared with [OctonionAlgebras.eqOctonionStrict], NOT with Kotest's
+ * structural `shouldBe`. The generated `CD`/`data class` `equals` boxes its `Double` components, so
+ * `(0.0).equals(-0.0)` is `false`; additive inversion of a basis unit produces `-0.0` components, which
+ * would spuriously fail a structural comparison even though the values are mathematically equal. The
+ * algebra's own `Eq` compares through real equality, where `0.0 == -0.0`.
+ */
+object OctonionFanoOrientationSpec : StringSpec({
+
+    val ring = OctonionAlgebras.OctonionDivisionAlgebraReal
+    val eq = OctonionAlgebras.eqOctonionStrict
+    val pr = OctonionAlgebras.printableOctonionStrict
+
+    val basis = (1..7).associateWith { ring.basisMap.getValue(it) }
+    fun neg(i: Int) = ring.add.inverse(basis.getValue(i))
+
+    // Signed-zero-safe octonion equality assertion (see class kdoc).
+    infix fun Octonion.shouldEqualOctonion(expected: Octonion) {
+        if (eq.neqv(this, expected))
+            fail("expected ${pr(expected)} but was ${pr(this)}")
+    }
+
+    "derived orientation matches the underlying (unoriented) Fano plane" {
+        val orientation = OctonionFanoOrientations.deriveFromCurrentBasis()
+        val underlying = orientation.lines.map { it.toFiniteSet() }.toUnorderedFiniteSet()
+        val expected = FanoPlane.lines.map { it.toFiniteSet() }.toUnorderedFiniteSet()
+        underlying shouldBe expected
+    }
+
+    "each oriented line (a,b,c) is a positively cyclic quaternionic triple: e_a e_b = e_c, e_b e_c = e_a, e_c e_a = e_b" {
+        val orientation = OctonionFanoOrientations.deriveFromCurrentBasis()
+        orientation.lines.forEach { line ->
+            ring.mul(basis.getValue(line.a), basis.getValue(line.b)) shouldEqualOctonion basis.getValue(line.c)
+            ring.mul(basis.getValue(line.b), basis.getValue(line.c)) shouldEqualOctonion basis.getValue(line.a)
+            ring.mul(basis.getValue(line.c), basis.getValue(line.a)) shouldEqualOctonion basis.getValue(line.b)
+        }
+    }
+
+    // This is the strongest check: it ties the OctonionFanoOrientation API (sign + thirdPoint),
+    // i.e. OrientedFanoLine.signOfOrderedPair, directly to the octonion product for ALL 42 ordered
+    // pairs of distinct basis indices. Every distinct pair lies on exactly one Fano line, so this
+    // exhausts the multiplication table for the imaginary basis units.
+    "sign(i,j) and thirdPoint(i,j) reproduce the basis multiplication for every ordered pair" {
+        val orientation = OctonionFanoOrientations.deriveFromCurrentBasis()
+        for (i in 1..7) for (j in 1..7) {
+            if (i == j) continue
+            val k = orientation.thirdPoint(i, j)
+            val sign = orientation.sign(i, j)
+            val expected = if (sign == 1) basis.getValue(k) else neg(k)
+            ring.mul(basis.getValue(i), basis.getValue(j)) shouldEqualOctonion expected
+        }
+    }
+
+    // signOfOrderedPair must be exactly antisymmetric: reversing an ordered pair flips the sign,
+    // mirroring anticommutativity e_i e_j = - e_j e_i of the imaginary octonion units.
+    "orientation sign is antisymmetric in its arguments" {
+        val orientation = OctonionFanoOrientations.deriveFromCurrentBasis()
+        for (i in 1..7) for (j in 1..7) {
+            if (i == j) continue
+            orientation.sign(i, j) shouldBe -orientation.sign(j, i)
+        }
+    }
+})

--- a/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionNonAssociativitySpec.kt
+++ b/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionNonAssociativitySpec.kt
@@ -7,8 +7,9 @@ import io.kotest.core.spec.style.StringSpec
  * Confirms that [OctonionAlgebras.OctonionDivisionAlgebraReal] is *genuinely* non-associative, i.e. that
  * the Cayley-Dickson doubling of the quaternions did not collapse into something accidentally associative.
  *
- * The alternativity and Moufang law suites confirm the *weak* associativity that the octonions DO satisfy;
- * this spec is the complementary negative check: it exhibits an explicit associator that does not vanish.
+ * [OctonionAlternativitySpec] confirms the *weak* associativity that the octonions DO satisfy
+ * (alternativity and the Moufang identities); this spec is the complementary negative check: it
+ * exhibits an explicit associator that does not vanish.
  *
  * Witness: three imaginary units that do NOT share a Fano line, e.g. e1, e2, e4 (the line through 1 and 2
  * is {1,2,3}, which excludes 4). For such a triple the associator

--- a/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionNonAssociativitySpec.kt
+++ b/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionNonAssociativitySpec.kt
@@ -1,0 +1,55 @@
+package org.vorpal.kosmos.hypercomplex.octonion
+
+import io.kotest.assertions.fail
+import io.kotest.core.spec.style.StringSpec
+
+/**
+ * Confirms that [OctonionAlgebras.OctonionDivisionAlgebraReal] is *genuinely* non-associative, i.e. that
+ * the Cayley-Dickson doubling of the quaternions did not collapse into something accidentally associative.
+ *
+ * The alternativity and Moufang law suites confirm the *weak* associativity that the octonions DO satisfy;
+ * this spec is the complementary negative check: it exhibits an explicit associator that does not vanish.
+ *
+ * Witness: three imaginary units that do NOT share a Fano line, e.g. e1, e2, e4 (the line through 1 and 2
+ * is {1,2,3}, which excludes 4). For such a triple the associator
+ *
+ *     [a, b, c] = (a b) c - a (b c)
+ *
+ * is non-zero; concretely (e1 e2) e4 - e1 (e2 e4) = 2 e7. For an on-line (quaternionic) triple the
+ * associator vanishes, since each Fano line spans an associative ℍ-subalgebra.
+ *
+ * Octonion products are compared with [OctonionAlgebras.eqOctonionStrict] (signed-zero-safe), never the
+ * structural `shouldBe`; see [OctonionFanoOrientationSpec].
+ */
+object OctonionNonAssociativitySpec : StringSpec({
+
+    val ring = OctonionAlgebras.OctonionDivisionAlgebraReal
+    val eq = OctonionAlgebras.eqOctonionStrict
+    val pr = OctonionAlgebras.printableOctonionStrict
+
+    fun e(i: Int): Octonion = ring.basisMap.getValue(i)
+
+    /** The associator [a, b, c] = (a b) c - a (b c). */
+    fun associator(a: Octonion, b: Octonion, c: Octonion): Octonion =
+        ring.add(
+            ring.mul(ring.mul(a, b), c),
+            ring.add.inverse(ring.mul(a, ring.mul(b, c)))
+        )
+
+    infix fun Octonion.shouldEqualOctonion(expected: Octonion) {
+        if (eq.neqv(this, expected))
+            fail("expected ${pr(expected)} but was ${pr(this)}")
+    }
+
+    "octonion multiplication is genuinely non-associative: the off-line associator [e1, e2, e4] is non-zero" {
+        val assoc = associator(e(1), e(2), e(4))
+        if (eq(assoc, ring.zero))
+            fail("expected a non-zero associator [e1, e2, e4], proving non-associativity, but it vanished")
+        // Sharper, structural form: the associator is exactly 2 e7.
+        assoc shouldEqualOctonion ring.add(e(7), e(7))
+    }
+
+    "the associator vanishes within an on-line (quaternionic) triple [e1, e2, e3]" {
+        associator(e(1), e(2), e(3)) shouldEqualOctonion ring.zero
+    }
+})

--- a/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionRealNormedDivisionAlgebraSpec.kt
+++ b/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionRealNormedDivisionAlgebraSpec.kt
@@ -1,0 +1,31 @@
+package org.vorpal.kosmos.hypercomplex.octonion
+
+import io.kotest.core.spec.style.StringSpec
+import org.vorpal.kosmos.algebra.structures.instances.RealAlgebras
+import org.vorpal.kosmos.laws.algebra.RealNormedDivisionAlgebraLaws
+
+/**
+ * Property tests for [OctonionAlgebras.OctonionDivisionAlgebraReal] as a
+ * [org.vorpal.kosmos.algebra.structures.RealNormedDivisionAlgebra].
+ *
+ * This is the real "does Cayley-Dickson on the quaternions actually give the octonions" check:
+ * [RealNormedDivisionAlgebraLaws] bundles the non-associative involutive ring laws, multiplicative
+ * invertibility (so 𝕆 is genuinely a division algebra), multiplicativity of the squared norm
+ * `N(xy) = N(x)N(y)` (the composition-algebra property), positive-definiteness of `N`, and the
+ * `‖a‖² = max(0, N(a))` consistency relation.
+ *
+ * We draw from [ArbOctonion.reciprocalSafeOctonion] so that the invertibility law never hits the
+ * `normSq ≈ 0` guard in the reciprocal, and the multiplicative norm law stays numerically well-conditioned.
+ */
+object OctonionRealNormedDivisionAlgebraSpec : StringSpec({
+    "OctonionDivisionAlgebraReal satisfies RealNormedDivisionAlgebraLaws" {
+        RealNormedDivisionAlgebraLaws(
+            algebra = OctonionAlgebras.OctonionDivisionAlgebraReal,
+            arb = ArbOctonion.reciprocalSafeOctonion,
+            eqA = OctonionAlgebras.eqOctonion,
+            eqReal = RealAlgebras.eqRealApprox,
+            prA = OctonionAlgebras.printableOctonionPretty,
+            prReal = RealAlgebras.printableRealPretty
+        ).fullTest().throwIfFailed()
+    }
+})

--- a/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionStarAlgebraSpec.kt
+++ b/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/octonion/OctonionStarAlgebraSpec.kt
@@ -1,0 +1,30 @@
+package org.vorpal.kosmos.hypercomplex.octonion
+
+import io.kotest.core.spec.style.StringSpec
+import org.vorpal.kosmos.algebra.structures.instances.ArbReal
+import org.vorpal.kosmos.algebra.structures.instances.RealAlgebras
+import org.vorpal.kosmos.laws.algebra.NonAssociativeStarAlgebraLaws
+
+/**
+ * Property tests for [OctonionAlgebras.OctonionStarAlgebra] as a
+ * [org.vorpal.kosmos.algebra.structures.NonAssociativeStarAlgebra] over ℝ.
+ *
+ * We deliberately use [NonAssociativeStarAlgebraLaws] rather than [org.vorpal.kosmos.laws.algebra.StarAlgebraLaws]:
+ * the octonions are non-associative, so the associativity law bundled into the latter must NOT be imposed.
+ * This suite covers the non-associative algebra laws (bilinearity of the product, scalar compatibility with
+ * the central real action), the conjugation laws (involution and the order-reversing `(xy)* = y* x*`), and
+ * commutation of the star with the scalar action.
+ */
+object OctonionStarAlgebraSpec : StringSpec({
+    "OctonionStarAlgebra satisfies NonAssociativeStarAlgebraLaws" {
+        NonAssociativeStarAlgebraLaws(
+            algebra = OctonionAlgebras.OctonionStarAlgebra,
+            scalarArb = ArbReal.smallReal,
+            algebraArb = ArbOctonion.octonion,
+            eqR = RealAlgebras.eqRealApprox,
+            eqA = OctonionAlgebras.eqOctonion,
+            prR = RealAlgebras.printableRealPretty,
+            prA = OctonionAlgebras.printableOctonionPretty
+        ).fullTest().throwIfFailed()
+    }
+})

--- a/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/quaternion/QuaternionRealNormedDivisionAlgebraSpec.kt
+++ b/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/quaternion/QuaternionRealNormedDivisionAlgebraSpec.kt
@@ -1,0 +1,31 @@
+package org.vorpal.kosmos.hypercomplex.quaternion
+
+import io.kotest.core.spec.style.StringSpec
+import org.vorpal.kosmos.algebra.structures.instances.RealAlgebras
+import org.vorpal.kosmos.laws.algebra.RealNormedDivisionAlgebraLaws
+
+/**
+ * Property tests for [QuaternionAlgebras.QuaternionDivisionRing] as a
+ * [org.vorpal.kosmos.algebra.structures.RealNormedDivisionAlgebra].
+ *
+ * This is the quaternion analogue of `OctonionRealNormedDivisionAlgebraSpec`: it exercises the
+ * non-associative involutive ring laws (which ℍ of course also satisfies), multiplicative
+ * invertibility (ℍ is a division ring), multiplicativity of the squared norm `N(xy) = N(x)N(y)`
+ * (the composition-algebra property), positive-definiteness of `N`, and the `‖a‖² = max(0, N(a))`
+ * consistency relation.
+ *
+ * We draw from [ArbQuaternion.reciprocalSafeQuaternion] so the invertibility law never hits the
+ * `normSq ≈ 0` guard in the reciprocal and the multiplicative-norm law stays well-conditioned.
+ */
+object QuaternionRealNormedDivisionAlgebraSpec : StringSpec({
+    "QuaternionDivisionRing satisfies RealNormedDivisionAlgebraLaws" {
+        RealNormedDivisionAlgebraLaws(
+            algebra = QuaternionAlgebras.QuaternionDivisionRing,
+            arb = ArbQuaternion.reciprocalSafeQuaternion,
+            eqA = QuaternionAlgebras.eqQuaternion,
+            eqReal = RealAlgebras.eqRealApprox,
+            prA = QuaternionAlgebras.printableQuaternionPretty,
+            prReal = RealAlgebras.printableRealPretty
+        ).fullTest().throwIfFailed()
+    }
+})

--- a/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/quaternion/QuaternionStarAlgebraSpec.kt
+++ b/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/quaternion/QuaternionStarAlgebraSpec.kt
@@ -1,0 +1,30 @@
+package org.vorpal.kosmos.hypercomplex.quaternion
+
+import io.kotest.core.spec.style.StringSpec
+import org.vorpal.kosmos.algebra.structures.instances.ArbReal
+import org.vorpal.kosmos.algebra.structures.instances.RealAlgebras
+import org.vorpal.kosmos.laws.algebra.StarAlgebraLaws
+
+/**
+ * Property tests for [QuaternionAlgebras.QuaternionStarAlgebra] as an (associative)
+ * [org.vorpal.kosmos.algebra.structures.StarAlgebra] over ℝ.
+ *
+ * Unlike the octonions, ℍ is associative, so we use the associative [StarAlgebraLaws] here: it bundles
+ * the non-associative star-algebra laws (bilinearity of the product, scalar compatibility with the
+ * central real action, the involution and order-reversing `(xy)* = y* x*`) together with an
+ * [org.vorpal.kosmos.laws.property.AssociativityLaw] on the product — which is exactly the property
+ * that distinguishes ℍ from 𝕆.
+ */
+object QuaternionStarAlgebraSpec : StringSpec({
+    "QuaternionStarAlgebra satisfies StarAlgebraLaws" {
+        StarAlgebraLaws(
+            algebra = QuaternionAlgebras.QuaternionStarAlgebra,
+            scalarArb = ArbReal.smallReal,
+            algebraArb = ArbQuaternion.quaternion,
+            eqR = RealAlgebras.eqRealApprox,
+            eqA = QuaternionAlgebras.eqQuaternion,
+            prR = RealAlgebras.printableRealPretty,
+            prA = QuaternionAlgebras.printableQuaternionPretty
+        ).fullTest().throwIfFailed()
+    }
+})

--- a/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/quaternion/QuaternionWeakAssociativitySpec.kt
+++ b/kosmos-testkit/src/test/kotlin/org/vorpal/kosmos/hypercomplex/quaternion/QuaternionWeakAssociativitySpec.kt
@@ -1,0 +1,43 @@
+package org.vorpal.kosmos.hypercomplex.quaternion
+
+import io.kotest.core.spec.style.StringSpec
+import org.vorpal.kosmos.laws.property.AlternativityLaw
+import org.vorpal.kosmos.laws.property.BolIdentityLaw
+import org.vorpal.kosmos.laws.property.FlexibilityLaw
+import org.vorpal.kosmos.laws.property.MoufangLaw
+
+/**
+ * The quaternions are associative, so they satisfy every "weak associativity" identity in the loop
+ * hierarchy as an immediate consequence: alternativity, the Moufang identities, both Bol identities,
+ * and flexibility. (Associative ⟹ Moufang ⟹ {left,right} Bol and alternative ⟹ flexible.)
+ *
+ * Running these against ℍ therefore serves two purposes:
+ *  1. It positively confirms ℍ sits at the top of the hierarchy (a sanity counterpart to
+ *     `QuaternionStarAlgebraSpec`'s direct associativity check).
+ *  2. It exercises the law implementations themselves on a structure where every identity *must* hold,
+ *     acting as a regression guard — in particular for [MoufangLaw], whose middle identity was recently
+ *     corrected, and for the [BolIdentityLaw]/[FlexibilityLaw] formulas.
+ */
+object QuaternionWeakAssociativitySpec : StringSpec({
+
+    val op = QuaternionAlgebras.QuaternionDivisionRing.mul.op
+    val arb = ArbQuaternion.quaternion
+    val eq = QuaternionAlgebras.eqQuaternion
+    val pr = QuaternionAlgebras.printableQuaternionPretty
+
+    "quaternion multiplication is alternative" {
+        AlternativityLaw(op, arb, eq, pr).test()
+    }
+
+    "quaternion multiplication satisfies the Moufang identities" {
+        MoufangLaw(op, arb, eq, pr).test()
+    }
+
+    "quaternion multiplication satisfies both Bol identities" {
+        BolIdentityLaw(op, arb, eq, pr).test()
+    }
+
+    "quaternion multiplication is flexible" {
+        FlexibilityLaw(op, arb, eq, pr).test()
+    }
+})


### PR DESCRIPTION
- Added derivation of the order on the lines of the Fano plane in the Octonion construction and test cases for the Octonions.
- Fixed MiddleMoufangLaw.
- Added tests for Quaternions.